### PR TITLE
Add word limit option to Prompt Lab

### DIFF
--- a/frontend/src/pages/PromptLab.tsx
+++ b/frontend/src/pages/PromptLab.tsx
@@ -225,7 +225,7 @@ export default function PromptLab() {
               <span className="w-4 h-4 inline-flex items-center justify-center rounded-full border border-ink-muted text-ink-muted text-xs cursor-help">
                 ?
               </span>
-              <span className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-2 py-1 text-xs text-white bg-ink rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+              <span className="absolute left-full ml-2 top-1/2 -translate-y-1/2 px-2 py-1 text-xs text-white bg-ink rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
                 Appends "Limit your response to N words." to your prompt
               </span>
             </span>


### PR DESCRIPTION
## Summary
- Adds optional word limit instruction to Prompt Lab prompts
- Checkbox + number input below prompt textarea (enabled by default, 50 words)
- Appends "Limit your response to N words." when enabled
- Number input blocks non-integer characters (e, +, -)

## Test plan
- [x] Verified UI renders with Playwright
- [x] Confirmed checkbox toggle enables/disables input
- [x] Confirmed 'e' key blocked in number input
- [x] All 42 unit tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)