### PR TITLE
Add Use Prompt link in prompt history

### DIFF
--- a/docs/plans/2026-01-11-use-prompt-feature-design.md
+++ b/docs/plans/2026-01-11-use-prompt-feature-design.md
@@ -1,0 +1,66 @@
+# Use Prompt Feature Design
+
+## Summary
+
+Add a "Use Prompt" link in the prompt history view that navigates to Prompt Lab with the prompt text and model selection pre-filled.
+
+## URL Structure
+
+Navigate to:
+```
+/prompt-lab?prompt=<urlEncoded>&models=<id1,id2,id3>
+```
+
+Example:
+```
+/prompt-lab?prompt=What%20is%20the%20capital%20of%20France%3F&models=gpt-4o,claude-sonnet-4-5,gemini-2-flash
+```
+
+## UI Changes
+
+### PromptCard Layout
+
+```
+┌─────────────────────────────────────────────────────┐
+│ "What is the capital of France?"          [Expand]  │
+│ Jan 10, 2026 · 5 models                [Use Prompt] │
+└─────────────────────────────────────────────────────┘
+```
+
+- Row 1: Prompt text left, [Expand] right
+- Row 2: Metadata left, [Use Prompt] right
+- Styled as a text link
+
+## PromptLab Changes
+
+Read URL parameters on mount and pre-fill:
+
+```typescript
+const [searchParams] = useSearchParams();
+
+useEffect(() => {
+  const promptParam = searchParams.get('prompt');
+  const modelsParam = searchParams.get('models');
+
+  if (promptParam) {
+    setPrompt(decodeURIComponent(promptParam));
+  }
+
+  if (modelsParam) {
+    const modelIds = modelsParam.split(',');
+    setSelectedModels(modelIds);
+  }
+}, []);
+```
+
+## Edge Cases
+
+- If a model ID from history no longer exists, it is silently ignored (won't appear selected)
+- Long prompts may approach URL length limits but typical prompts are short enough
+
+## Implementation Steps
+
+1. Update PromptCard layout to two-row structure with right-aligned controls
+2. Add "Use Prompt" link that builds URL from prompt text and response model IDs
+3. Update PromptLab to read `prompt` and `models` query params on mount
+4. Pre-fill prompt textarea and model selection from params

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import {
   NavLink,
   Navigate,
   useSearchParams,
+  Link,
 } from 'react-router-dom';
 import TopicList from './components/TopicList';
 import ResponseView from './components/ResponseView';
@@ -30,22 +31,32 @@ function PromptCard({ query }: { query: PromptLabQuery }) {
 
   return (
     <div className="bg-white border border-border rounded-lg p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex-1 min-w-0">
-          <p className="text-sm text-ink line-clamp-2">{query.prompt}</p>
-          <div className="mt-2 flex items-center gap-3 text-xs text-ink-muted">
+      <div className="space-y-1">
+        {/* Row 1: Prompt + Expand */}
+        <div className="flex items-start justify-between gap-4">
+          <p className="text-sm text-ink line-clamp-2 flex-1 min-w-0">{query.prompt}</p>
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="text-xs text-amber hover:text-amber-dark shrink-0"
+          >
+            {expanded ? 'Collapse' : 'Expand'}
+          </button>
+        </div>
+        {/* Row 2: Metadata + Use Prompt */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3 text-xs text-ink-muted">
             <span>{date.toLocaleDateString()}</span>
             <span>
               {query.responses.length} model{query.responses.length !== 1 ? 's' : ''}
             </span>
           </div>
+          <Link
+            to={`/prompt-lab?prompt=${encodeURIComponent(query.prompt)}&models=${query.responses.map((r) => r.model).join(',')}`}
+            className="text-xs text-amber hover:text-amber-dark"
+          >
+            Use Prompt
+          </Link>
         </div>
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="text-xs text-amber hover:text-amber-dark shrink-0"
-        >
-          {expanded ? 'Collapse' : 'Expand'}
-        </button>
       </div>
       {expanded && (
         <div className="mt-4 space-y-3 border-t border-border pt-4">

--- a/frontend/src/pages/PromptLab.tsx
+++ b/frontend/src/pages/PromptLab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import type { Model } from '../types';
 import { renderMarkdown } from '../utils/markdown';
 import ModelSelector from '../components/ModelSelector';
@@ -22,6 +23,15 @@ export default function PromptLab() {
   const [apiKey, setApiKey] = useState('');
   const [results, setResults] = useState<Map<string, ModelResult>>(new Map());
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [searchParams] = useSearchParams();
+
+  // Pre-fill prompt from URL params on mount
+  useEffect(() => {
+    const promptParam = searchParams.get('prompt');
+    if (promptParam) {
+      setPrompt(promptParam);
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     fetch('/api/models')
@@ -30,7 +40,21 @@ export default function PromptLab() {
         const modelList = data.models || [];
         setModels(modelList);
 
-        // Auto-select the most recent model per company
+        // Check for URL param models first
+        const modelsParam = searchParams.get('models');
+        if (modelsParam) {
+          const modelParams = modelsParam.split(',').filter(Boolean);
+          // Match by id or model_name (prompt history uses model_name)
+          const matchingIds = modelList
+            .filter((m) => modelParams.includes(m.id) || modelParams.includes(m.model_name))
+            .map((m) => m.id);
+          if (matchingIds.length > 0) {
+            setSelectedModels(new Set(matchingIds));
+            return;
+          }
+        }
+
+        // Otherwise auto-select the most recent model per company
         const byCompany = new Map<string, Model>();
         for (const model of modelList) {
           const existing = byCompany.get(model.company);
@@ -47,7 +71,7 @@ export default function PromptLab() {
         }
         setSelectedModels(new Set(Array.from(byCompany.values()).map(m => m.id)));
       });
-  }, []);
+  }, [searchParams]);
 
   const toggleModel = (id: string) => {
     setSelectedModels((prev) => {


### PR DESCRIPTION
## Summary

- Adds a "Use Prompt" link to each prompt card in the history view
- When clicked, navigates to Prompt Lab with prompt text and model selection pre-filled via URL parameters
- Restructures PromptCard to two-row layout with controls aligned on the right

## Changes

- **PromptCard**: New layout with prompt/expand on row 1, metadata/use-prompt on row 2
- **PromptLab**: Reads `prompt` and `models` URL params to pre-fill form on load
- **Design doc**: Added to `docs/plans/`

## Test plan

- [ ] Navigate to Browse → Prompt History
- [ ] Verify "Use Prompt" link appears on each prompt card (right side, row 2)
- [ ] Click "Use Prompt" on a card
- [ ] Verify navigation to Prompt Lab with:
  - Prompt textarea pre-filled with the historical prompt
  - Models from that query pre-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)