### PR TITLE
Add soft-delete for collections and enhance browsing UX

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -114,6 +114,7 @@ export interface Collection {
   template_id: string;
   prompt_text: string;
   display_name: string | null;
+  disabled: number;
   created_at: string;
   last_run_at: string | null;
   topic_name: string;

--- a/migrations/0001_add_disabled_to_collections.sql
+++ b/migrations/0001_add_disabled_to_collections.sql
@@ -1,0 +1,2 @@
+-- Add disabled column for soft-delete
+ALTER TABLE collections ADD COLUMN disabled INTEGER NOT NULL DEFAULT 0;

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -65,6 +65,7 @@ CREATE TABLE IF NOT EXISTS collections (
     template_id TEXT NOT NULL REFERENCES prompt_templates(id),
     prompt_text TEXT NOT NULL,                                    -- Rendered prompt (immutable snapshot)
     display_name TEXT,                                            -- Optional custom name, null = auto-generate
+    disabled INTEGER NOT NULL DEFAULT 0,                          -- Soft-delete flag
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     last_run_at TEXT                                              -- Updated after each run
 );

--- a/src/services/bigquery.ts
+++ b/src/services/bigquery.ts
@@ -679,7 +679,7 @@ export interface PromptLabQuery {
  */
 export async function getRecentPrompts(
   env: BigQueryEnv,
-  options: { limit?: number; search?: string; models?: string[]; companies?: string[]; topics?: string[] } = {}
+  options: { limit?: number; search?: string; models?: string[]; companies?: string[]; topics?: string[]; sources?: string[] } = {}
 ): Promise<BigQueryResult<PromptLabQuery[]>> {
   const tokenResult = await getAccessToken(env);
   if (!tokenResult.success) {
@@ -795,6 +795,18 @@ export async function getRecentPrompts(
         name: `topic_${i}`,
         parameterType: { type: 'STRING' },
         parameterValue: { value: topic },
+      });
+    });
+  }
+
+  if (options.sources && options.sources.length > 0) {
+    const sourceConditions = options.sources.map((_, i) => `source = @source_${i}`).join(' OR ');
+    query += ` AND (${sourceConditions})`;
+    options.sources.forEach((source, i) => {
+      queryParameters.push({
+        name: `source_${i}`,
+        parameterType: { type: 'STRING' },
+        parameterValue: { value: source },
       });
     });
   }


### PR DESCRIPTION
## Summary

- **Soft-delete for collections**: Collections are now disabled instead of deleted, preserving data for research purposes
  - Added `disabled` column to collections table with migration
  - Toggle to show/hide disabled collections in Manage tab
  - Restore button to re-enable disabled collections
  - Visual indicator (strikethrough, opacity) for disabled items

- **Fixed edit form**: Collection edit form now correctly loads selected models

- **Response display after collection run**: Responses are displayed after running a collection, matching PromptLab's expandable card style with model info, tokens, and latency

- **Source filter for prompts browsing**: Added checkboxes to filter between "Collections" and "Ad Hoc Prompts" in the Browse > Prompts tab

## Test plan

- [ ] Create a collection, verify it runs and displays responses below
- [ ] Edit a collection, verify models are pre-selected
- [ ] Delete a collection, verify it becomes disabled (not deleted)
- [ ] Toggle "Show disabled collections" checkbox
- [ ] Restore a disabled collection
- [ ] Browse prompts with source filter checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)