### PR TITLE
Update default OpenAI model to GPT-5.2

### DIFF
--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -9,7 +9,7 @@ INSERT OR IGNORE INTO prompt_templates (id, name, template, description) VALUES
 
 -- Initial models (four providers for MVP)
 INSERT OR IGNORE INTO models (id, provider, model_name, display_name) VALUES
-  ('openai-gpt4o', 'openai', 'gpt-4o', 'GPT-4o'),
+  ('openai-gpt52', 'openai', 'gpt-5.2', 'GPT-5.2'),
   ('anthropic-claude-sonnet', 'anthropic', 'claude-sonnet-4-5-20250929', 'Claude Sonnet 4.5'),
   ('google-gemini-flash', 'google', 'gemini-2.0-flash', 'Gemini 2.0 Flash'),
   ('cloudflare-llama', 'cloudflare', '@cf/meta/llama-3.1-8b-instruct-fast', 'Llama 3.1 8B'),

--- a/scripts/update-pricing.sql
+++ b/scripts/update-pricing.sql
@@ -44,7 +44,7 @@ UPDATE models SET input_price_per_m = 1.00, output_price_per_m = 4.00 WHERE mode
 UPDATE models SET input_price_per_m = 0.25, output_price_per_m = 1.00 WHERE model_name LIKE 'gpt-5-nano%';
 UPDATE models SET input_price_per_m = 10.00, output_price_per_m = 40.00 WHERE model_name LIKE 'gpt-5-pro%';
 UPDATE models SET input_price_per_m = 5.00, output_price_per_m = 15.00 WHERE model_name LIKE 'gpt-5.1%';
-UPDATE models SET input_price_per_m = 5.00, output_price_per_m = 15.00 WHERE model_name LIKE 'gpt-5.2%';
+UPDATE models SET input_price_per_m = 1.75, output_price_per_m = 14.00 WHERE model_name LIKE 'gpt-5.2%';
 
 -- OpenAI o-series reasoning models
 UPDATE models SET input_price_per_m = 15.00, output_price_per_m = 60.00 WHERE model_name = 'o1' OR model_name LIKE 'o1-2024%';


### PR DESCRIPTION
## Summary
- Changes default OpenAI model from `gpt-4o` to `gpt-5.2` (GPT-5.2 Thinking)
- Updates GPT-5.2 pricing to current rates: $1.75 input / $14 output per M tokens

## Context
GPT-5.2 is the latest flagship GPT model. Excluded `gpt-5.2-pro` and `gpt-5.2-chat-latest` per user request.

## Test plan
- [x] Unit tests pass (88/88)
- [ ] Verify model works in Prompt Lab after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)