### PR TITLE
Add advanced filters to Explore Models page

### DIFF
--- a/frontend/src/pages/ExploreModels.tsx
+++ b/frontend/src/pages/ExploreModels.tsx
@@ -167,21 +167,40 @@ function MultiSelect({
       {open && (
         <>
           <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-          <div className="absolute top-full left-0 mt-1 bg-white border border-border rounded-lg shadow-lg z-20 min-w-[200px] max-h-64 overflow-y-auto">
-            {options.map((option) => (
-              <label
-                key={option}
-                className="flex items-center gap-2 px-3 py-2 hover:bg-paper cursor-pointer text-sm"
+          <div className="absolute top-full left-0 mt-1 bg-white border border-border rounded-lg shadow-lg z-20 min-w-[200px]">
+            <div className="flex gap-2 px-3 py-2 border-b border-border">
+              <button
+                type="button"
+                onClick={() => onChange(new Set(options))}
+                className="text-xs text-amber hover:underline"
               >
-                <input
-                  type="checkbox"
-                  checked={selected.has(option)}
-                  onChange={() => toggleValue(option)}
-                  className="rounded"
-                />
-                <span className="truncate">{option}</span>
-              </label>
-            ))}
+                Select all
+              </button>
+              <span className="text-ink-muted">|</span>
+              <button
+                type="button"
+                onClick={() => onChange(new Set())}
+                className="text-xs text-amber hover:underline"
+              >
+                Clear
+              </button>
+            </div>
+            <div className="max-h-64 overflow-y-auto">
+              {options.map((option) => (
+                <label
+                  key={option}
+                  className="flex items-center gap-2 px-3 py-2 hover:bg-paper cursor-pointer text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.has(option)}
+                    onChange={() => toggleValue(option)}
+                    className="rounded"
+                  />
+                  <span className="truncate">{option}</span>
+                </label>
+              ))}
+            </div>
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary
- Add **Family** multi-select filter for filtering by model family (GPT, Claude, Gemini, etc.)
- Add **Capability checkboxes** for filtering by: Reasoning, Tools, Attachments, Open Weights (AND logic)
- Add **Release Date dropdown** with presets (Any, Last 6 months, Last year, 2026, 2025, Older) + custom date picker
- Reorganize filters into **two rows** for better layout
- **URL persistence** for all filters (shareable filter states)

## Technical Details
- Dynamic year presets computed from `CURRENT_YEAR` (won't go stale)
- Timezone-consistent date comparison using string comparison
- Date range validation with auto-swap when from > to
- Proper accessibility: aria-labels, label associations with htmlFor

## Test plan
- [ ] Verify Family filter shows unique families from models
- [ ] Verify capability checkboxes use AND logic (selecting multiple narrows results)
- [ ] Verify release date presets filter correctly
- [ ] Verify custom date range works (including auto-swap validation)
- [ ] Verify URL params persist filter state on refresh
- [ ] Verify Clear filters button resets all filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)