### PR TITLE
Fix cron scheduling: use scheduledTime instead of current time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,8 +41,9 @@ export default {
     }
 
     // Collection scheduler runs every minute (checks cron expressions)
+    // Pass scheduledTime to ensure cron matching uses the trigger time, not execution time
     ctx.waitUntil(
-      runScheduledCollections(env).then((result) => {
+      runScheduledCollections(env, scheduledTime).then((result) => {
         if (result.ran > 0) {
           console.log(`Scheduled collections: ran ${result.ran} of ${result.checked} collections`);
         }
@@ -50,8 +51,9 @@ export default {
     );
 
     // Observation scheduler runs every minute (checks cron expressions)
+    // Pass scheduledTime to ensure cron matching uses the trigger time, not execution time
     ctx.waitUntil(
-      runScheduledObservations(env).then((result) => {
+      runScheduledObservations(env, scheduledTime).then((result) => {
         if (result.ran > 0) {
           console.log(`Scheduled observations: ran ${result.ran} of ${result.checked} observations`);
         }

--- a/src/services/collection-scheduler.ts
+++ b/src/services/collection-scheduler.ts
@@ -76,8 +76,13 @@ function matchCronField(field: string, value: number): boolean {
 
 /**
  * Run all scheduled collections that are due
+ * @param env - Environment bindings
+ * @param scheduledTime - The time the cron trigger fired (not the execution time)
  */
-export async function runScheduledCollections(env: Env): Promise<{
+export async function runScheduledCollections(
+  env: Env,
+  scheduledTime: Date
+): Promise<{
   checked: number;
   ran: number;
   results: Array<{
@@ -87,7 +92,6 @@ export async function runScheduledCollections(env: Env): Promise<{
     error?: string;
   }>;
 }> {
-  const now = new Date();
   const collections = await getCollections(env.DB);
 
   const results: Array<{
@@ -105,8 +109,8 @@ export async function runScheduledCollections(env: Env): Promise<{
       continue;
     }
 
-    // Check if cron matches current time
-    if (!cronMatchesNow(collection.cron_expression, now)) {
+    // Check if cron matches the scheduled trigger time (not current execution time)
+    if (!cronMatchesNow(collection.cron_expression, scheduledTime)) {
       continue;
     }
 

--- a/src/services/observation-scheduler.ts
+++ b/src/services/observation-scheduler.ts
@@ -97,8 +97,13 @@ function getEffectiveCron(observation: ObservationWithDetails): string | null {
 
 /**
  * Run all scheduled observations that are due
+ * @param env - Environment bindings
+ * @param scheduledTime - The time the cron trigger fired (not the execution time)
  */
-export async function runScheduledObservations(env: Env): Promise<{
+export async function runScheduledObservations(
+  env: Env,
+  scheduledTime: Date
+): Promise<{
   checked: number;
   ran: number;
   results: Array<{
@@ -108,7 +113,6 @@ export async function runScheduledObservations(env: Env): Promise<{
     error?: string;
   }>;
 }> {
-  const now = new Date();
   const observations = await getObservations(env.DB);
 
   const results: Array<{
@@ -131,8 +135,8 @@ export async function runScheduledObservations(env: Env): Promise<{
       continue;
     }
 
-    // Check if cron matches current time
-    if (!cronMatchesNow(cronExpression, now)) {
+    // Check if cron matches the scheduled trigger time (not current execution time)
+    if (!cronMatchesNow(cronExpression, scheduledTime)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Fix cron scheduler using wrong time source causing irregular execution
- Pass `event.scheduledTime` from cron trigger to scheduler functions
- Ensures cron matching uses intended trigger time, not actual execution time

## Root Cause
Scheduler functions were using `new Date()` to check if cron expressions match. If worker execution is delayed (cold start, queue time), the current time could drift into the next minute, causing cron expressions to miss their scheduled window.

## Test Plan
- [x] Lint passes
- [x] Unit tests pass (154/154)
- [x] Local scheduled trigger test (`/__scheduled?cron=*+*+*+*+*`) works
- [ ] Deploy to production
- [ ] Create test observation with `* * * * *` schedule
- [ ] Monitor execution history for 15-20 minutes
- [ ] Verify executions occur at expected intervals

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)