### PR TITLE
Fix cron scheduler duplicate executions

### DIFF
--- a/tests/services/swarm-scheduler.test.ts
+++ b/tests/services/swarm-scheduler.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { alreadyRanInCurrentMinute } from '../../src/services/swarm-scheduler';
+
+describe('Swarm Scheduler Idempotency', () => {
+  describe('alreadyRanInCurrentMinute', () => {
+    it('returns false when lastRunAt is null', () => {
+      const scheduledTime = new Date('2026-01-19T17:25:00.000Z');
+      const result = alreadyRanInCurrentMinute(null, scheduledTime);
+      expect(result).toBe(false);
+    });
+
+    it('returns true when lastRunAt matches the same minute', () => {
+      const lastRunAt = '2026-01-19T17:25:00.000Z';
+      const scheduledTime = new Date('2026-01-19T17:25:30.000Z');
+      const result = alreadyRanInCurrentMinute(lastRunAt, scheduledTime);
+      expect(result).toBe(true);
+    });
+
+    it('returns true when lastRunAt matches exactly', () => {
+      const lastRunAt = '2026-01-19T17:25:00.000Z';
+      const scheduledTime = new Date('2026-01-19T17:25:00.000Z');
+      const result = alreadyRanInCurrentMinute(lastRunAt, scheduledTime);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when lastRunAt is from previous minute', () => {
+      const lastRunAt = '2026-01-19T17:24:00.000Z';
+      const scheduledTime = new Date('2026-01-19T17:25:00.000Z');
+      const result = alreadyRanInCurrentMinute(lastRunAt, scheduledTime);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when lastRunAt is from next minute', () => {
+      const lastRunAt = '2026-01-19T17:26:00.000Z';
+      const scheduledTime = new Date('2026-01-19T17:25:00.000Z');
+      const result = alreadyRanInCurrentMinute(lastRunAt, scheduledTime);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when lastRunAt is from different hour', () => {
+      const lastRunAt = '2026-01-19T16:25:00.000Z';
+      const scheduledTime = new Date('2026-01-19T17:25:00.000Z');
+      const result = alreadyRanInCurrentMinute(lastRunAt, scheduledTime);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when lastRunAt is from different day', () => {
+      const lastRunAt = '2026-01-18T17:25:00.000Z';
+      const scheduledTime = new Date('2026-01-19T17:25:00.000Z');
+      const result = alreadyRanInCurrentMinute(lastRunAt, scheduledTime);
+      expect(result).toBe(false);
+    });
+
+    it('handles midnight boundary correctly', () => {
+      // 23:59 on one day and 00:00 on next day should be different
+      const lastRunAt = '2026-01-19T23:59:00.000Z';
+      const scheduledTime = new Date('2026-01-20T00:00:00.000Z');
+      const result = alreadyRanInCurrentMinute(lastRunAt, scheduledTime);
+      expect(result).toBe(false);
+    });
+
+    it('handles year boundary correctly', () => {
+      const lastRunAt = '2025-12-31T23:59:00.000Z';
+      const scheduledTime = new Date('2026-01-01T00:00:00.000Z');
+      const result = alreadyRanInCurrentMinute(lastRunAt, scheduledTime);
+      expect(result).toBe(false);
+    });
+
+    it('ignores seconds difference within same minute', () => {
+      const lastRunAt = '2026-01-19T17:25:15.000Z';
+      const scheduledTime = new Date('2026-01-19T17:25:45.000Z');
+      const result = alreadyRanInCurrentMinute(lastRunAt, scheduledTime);
+      expect(result).toBe(true);
+    });
+
+    it('ignores milliseconds difference within same minute', () => {
+      const lastRunAt = '2026-01-19T17:25:00.123Z';
+      const scheduledTime = new Date('2026-01-19T17:25:00.456Z');
+      const result = alreadyRanInCurrentMinute(lastRunAt, scheduledTime);
+      expect(result).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #54 - Cloudflare may invoke cron triggers from multiple data centers simultaneously, causing swarms to execute multiple times within the same minute.

## Changes

- Add `alreadyRanInCurrentMinute()` function to check if a swarm already ran in the current scheduled minute
- Update `last_run_at` **before** execution starts (not after) to prevent race conditions
- Use `scheduledTime` parameter for `last_run_at` so all triggers in the same minute see the same value
- Add double-check after update to detect if another worker won the race
- Update `updateSwarmLastRunAt()` to accept an optional timestamp parameter

## How it works

1. Before running a swarm, check if `last_run_at` falls within the current minute
2. If it does, skip execution (another instance already ran/is running)
3. If not, immediately update `last_run_at` to the scheduled time
4. Re-fetch the swarm and verify our update persisted (race detection)
5. Only then proceed with actual execution

## Test plan

- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] Unit tests pass (154 tests)
- [ ] Verify Cloudflare preview deployment succeeds
- [ ] Monitor production for duplicate executions after merge

---
Generated with [Claude Code](https://claude.com/code)