### PR TITLE
Add User-Agent header to bypass Cloudflare bot detection

### DIFF
--- a/dagster_definitions/resources.py
+++ b/dagster_definitions/resources.py
@@ -20,6 +20,7 @@ class ObservatoryApiResource(ConfigurableResource):
         return {
             "Accept": "application/json",
             "Content-Type": "application/json",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
             "CF-Access-Client-Id": self.cf_access_client_id,
             "CF-Access-Client-Secret": self.cf_access_client_secret,
         }


### PR DESCRIPTION
Cloudflare's bot detection (error 1010) was blocking Python urllib
requests. Add a browser-like User-Agent header.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
